### PR TITLE
feat: Add AWS EFS CSI driver support

### DIFF
--- a/components/helmrelease/aws-efs-csi.yaml
+++ b/components/helmrelease/aws-efs-csi.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: aws-efs-csi
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./components/helmrelease/aws-efs-csi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: flux-system
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: terraform-outputs

--- a/components/helmrelease/aws-efs-csi/helmrelease.yaml
+++ b/components/helmrelease/aws-efs-csi/helmrelease.yaml
@@ -1,0 +1,40 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: aws-efs-csi-driver
+  namespace: kube-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: aws-efs-csi-driver
+      version: "2.5.7"
+      sourceRef:
+        kind: HelmRepository
+        name: aws-efs-csi-driver
+        namespace: flux-system
+  values:
+    controller:
+      region: us-east-1
+      replicaCount: 1
+      serviceAccount:
+        create: true
+        name: efs-csi-controller-sa
+        annotations:
+          eks.amazonaws.com/role-arn: "${EFS_CSI_ROLE_ARN}"
+    node:
+      serviceAccount:
+        create: true
+        name: efs-csi-node-sa
+        annotations:
+          eks.amazonaws.com/role-arn: "${EFS_CSI_ROLE_ARN}"
+    storageClasses:
+      - name: efs-sc
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "false"
+        volumeBindingMode: Immediate
+        reclaimPolicy: Delete
+        parameters:
+          provisioningMode: efs-ap
+          fileSystemId: ""  # Will need to be set with actual EFS filesystem ID
+          directoryPerms: "700"

--- a/components/helmrelease/aws-efs-csi/helmrepository.yaml
+++ b/components/helmrelease/aws-efs-csi/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: aws-efs-csi-driver
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/aws-efs-csi-driver

--- a/components/helmrelease/aws-efs-csi/kustomization.yaml
+++ b/components/helmrelease/aws-efs-csi/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/components/tf_initialSeedCluster/eks/efs-csi.tf
+++ b/components/tf_initialSeedCluster/eks/efs-csi.tf
@@ -1,0 +1,81 @@
+data "aws_iam_policy_document" "efs_csi_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:efs-csi-controller-sa"]
+    }
+
+    principals {
+      identifiers = [module.eks.oidc_provider_arn]
+      type        = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "efs_csi_role" {
+  assume_role_policy = data.aws_iam_policy_document.efs_csi_assume_role.json
+  name               = "AmazonEKS_EFS_CSI_DriverRole"
+}
+
+resource "aws_iam_policy" "efs_csi_policy" {
+  name = "AmazonEKS_EFS_CSI_Driver_Policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticfilesystem:DescribeAccessPoints",
+          "elasticfilesystem:DescribeFileSystems",
+          "elasticfilesystem:DescribeMountTargets",
+          "ec2:DescribeAvailabilityZones"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticfilesystem:CreateAccessPoint"
+        ]
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "aws:RequestTag/efs.csi.aws.com/cluster" = "true"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticfilesystem:TagResource"
+        ]
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "aws:ResourceTag/efs.csi.aws.com/cluster" = "true"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = "elasticfilesystem:DeleteAccessPoint"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/efs.csi.aws.com/cluster" = "true"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "efs_csi_policy_attachment" {
+  policy_arn = aws_iam_policy.efs_csi_policy.arn
+  role       = aws_iam_role.efs_csi_role.name
+}

--- a/components/tf_initialSeedCluster/eks/k8s-outputs.tf
+++ b/components/tf_initialSeedCluster/eks/k8s-outputs.tf
@@ -8,6 +8,7 @@ resource "kubernetes_config_map" "terraform_outputs" {
   data = {
     AWS_ACCOUNT_ID                = data.aws_caller_identity.current.account_id
     EBS_CSI_ROLE_ARN              = aws_iam_role.ebs_csi_role.arn
+    EFS_CSI_ROLE_ARN              = aws_iam_role.efs_csi_role.arn
     EXTERNAL_SECRETS_ROLE_ARN     = aws_iam_role.external_secrets_role.arn
     ALB_CONTROLLER_ROLE_ARN       = aws_iam_role.alb_controller_role.arn
     CLUSTER_NAME                  = var.cluster_name


### PR DESCRIPTION
## Summary
- Adds AWS EFS CSI driver as a new option in the helmrelease components
- Enables dynamic provisioning of Amazon EFS volumes for Kubernetes workloads
- Follows the same pattern as the existing EBS CSI driver implementation

## Changes
### Terraform IAM Resources
- Created `components/tf_initialSeedCluster/eks/efs-csi.tf` with:
  - IAM role `AmazonEKS_EFS_CSI_DriverRole` with IRSA trust policy
  - IAM policy `AmazonEKS_EFS_CSI_Driver_Policy` with required EFS permissions
  - Service account trust for `system:serviceaccount:kube-system:efs-csi-controller-sa`

### Kubernetes Resources
- Created Flux Kustomization at `components/helmrelease/aws-efs-csi.yaml`
- Added HelmRelease configuration in `components/helmrelease/aws-efs-csi/`:
  - HelmRepository pointing to `https://kubernetes-sigs.github.io/aws-efs-csi-driver/`
  - HelmRelease with version `2.5.7` of the aws-efs-csi-driver chart
  - Service accounts configured with IRSA annotations using `${EFS_CSI_ROLE_ARN}`
  - Default storage class `efs-sc` (requires EFS filesystem ID to be set)

### Configuration Updates
- Updated `components/tf_initialSeedCluster/eks/k8s-outputs.tf` to include `EFS_CSI_ROLE_ARN` in the terraform-outputs ConfigMap

## Usage
1. Run `terraform apply` in the tf_initialSeedCluster directory to create the IAM resources
2. Reference the aws-efs-csi kustomization in your cluster configuration:
   ```yaml
   - name: aws-efs-csi
   ```
3. Create an EFS filesystem and update the `fileSystemId` parameter in the storage class

## Test Plan
- [ ] Terraform plan shows new IAM resources
- [ ] Flux reconciliation succeeds after referencing the kustomization
- [ ] EFS CSI driver pods start successfully with proper IRSA authentication
- [ ] Storage class can provision EFS access points when filesystem ID is configured