### PR TITLE
feat: Add AKS seed cluster Terraform configuration

### DIFF
--- a/components/tf_initialSeedCluster/aks/main.tf
+++ b/components/tf_initialSeedCluster/aks/main.tf
@@ -1,0 +1,74 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+
+  # You'll want to change this to your preferred backend
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# Configure the Kubernetes provider
+provider "kubernetes" {
+  host                   = azurerm_kubernetes_cluster.aks.kube_config.0.host
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.cluster_ca_certificate)
+}
+
+# Resource group
+resource "azurerm_resource_group" "aks" {
+  name     = "${var.cluster_name}-rg"
+  location = var.location
+  tags     = var.tags
+}
+
+# AKS Cluster
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = var.cluster_name
+  location            = azurerm_resource_group.aks.location
+  resource_group_name = azurerm_resource_group.aks.name
+  dns_prefix          = var.cluster_name
+  kubernetes_version  = var.kubernetes_version
+
+  default_node_pool {
+    name       = "default"
+    node_count = var.node_count
+    vm_size    = var.node_size
+    
+    # Use Azure CNI for better integration
+    vnet_subnet_id = azurerm_subnet.aks.id
+    
+    enable_auto_scaling = true
+    min_count          = var.min_node_count
+    max_count          = var.max_node_count
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin    = "azure"
+    network_policy    = "azure"
+    load_balancer_sku = "standard"
+    service_cidr      = var.service_cidr
+    dns_service_ip    = var.dns_service_ip
+  }
+
+  tags = var.tags
+}

--- a/components/tf_initialSeedCluster/aks/namespace.tf
+++ b/components/tf_initialSeedCluster/aks/namespace.tf
@@ -1,0 +1,16 @@
+resource "null_resource" "create_flux_ns" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      export KUBECONFIG="$(mktemp)"
+      echo '${azurerm_kubernetes_cluster.aks.kube_config_raw}' > "$KUBECONFIG"
+      kubectl get ns flux-system || kubectl create ns flux-system
+    EOT
+    interpreter = ["/bin/bash", "-c"]
+  }
+
+  triggers = {
+    cluster_endpoint = azurerm_kubernetes_cluster.aks.kube_config.0.host
+  }
+
+  depends_on = [azurerm_kubernetes_cluster.aks]
+}

--- a/components/tf_initialSeedCluster/aks/outputs.tf
+++ b/components/tf_initialSeedCluster/aks/outputs.tf
@@ -1,0 +1,50 @@
+output "cluster_name" {
+  description = "Name of the AKS cluster"
+  value       = azurerm_kubernetes_cluster.aks.name
+}
+
+output "cluster_id" {
+  description = "ID of the AKS cluster"
+  value       = azurerm_kubernetes_cluster.aks.id
+}
+
+output "kube_config" {
+  description = "Kubernetes config for connecting to the cluster"
+  value       = azurerm_kubernetes_cluster.aks.kube_config_raw
+  sensitive   = true
+}
+
+output "kube_config_host" {
+  description = "Kubernetes API server endpoint"
+  value       = azurerm_kubernetes_cluster.aks.kube_config.0.host
+}
+
+output "resource_group_name" {
+  description = "Name of the resource group"
+  value       = azurerm_resource_group.aks.name
+}
+
+output "vnet_id" {
+  description = "ID of the Virtual Network"
+  value       = azurerm_virtual_network.aks.id
+}
+
+output "vnet_name" {
+  description = "Name of the Virtual Network"
+  value       = azurerm_virtual_network.aks.name
+}
+
+output "aks_subnet_id" {
+  description = "ID of the AKS subnet"
+  value       = azurerm_subnet.aks.id
+}
+
+output "cluster_identity_principal_id" {
+  description = "Principal ID of the cluster managed identity"
+  value       = azurerm_kubernetes_cluster.aks.identity.0.principal_id
+}
+
+output "node_resource_group" {
+  description = "Name of the auto-generated resource group for AKS nodes"
+  value       = azurerm_kubernetes_cluster.aks.node_resource_group
+}

--- a/components/tf_initialSeedCluster/aks/outputs.tf
+++ b/components/tf_initialSeedCluster/aks/outputs.tf
@@ -17,6 +17,7 @@ output "kube_config" {
 output "kube_config_host" {
   description = "Kubernetes API server endpoint"
   value       = azurerm_kubernetes_cluster.aks.kube_config.0.host
+  sensitive   = true
 }
 
 output "resource_group_name" {

--- a/components/tf_initialSeedCluster/aks/variables.tf
+++ b/components/tf_initialSeedCluster/aks/variables.tf
@@ -1,0 +1,69 @@
+variable "cluster_name" {
+  description = "Name of the AKS cluster"
+  type        = string
+  default     = "fullStack-cluster"
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+  default     = "eastus"
+}
+
+variable "vnet_cidr" {
+  description = "CIDR block for Virtual Network"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "service_cidr" {
+  description = "CIDR block for Kubernetes services"
+  type        = string
+  default     = "10.1.0.0/16"
+}
+
+variable "dns_service_ip" {
+  description = "DNS service IP address (must be within service_cidr)"
+  type        = string
+  default     = "10.1.0.10"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for AKS"
+  type        = string
+  default     = "1.31"
+}
+
+variable "node_count" {
+  description = "Initial number of nodes"
+  type        = number
+  default     = 2
+}
+
+variable "min_node_count" {
+  description = "Minimum number of nodes for autoscaling"
+  type        = number
+  default     = 1
+}
+
+variable "max_node_count" {
+  description = "Maximum number of nodes for autoscaling"
+  type        = number
+  default     = 3
+}
+
+variable "node_size" {
+  description = "Size of the nodes"
+  type        = string
+  default     = "Standard_D2_v3"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    Environment = "dev"
+    Project     = "fullStack-cluster"
+    ManagedBy   = "terraform"
+  }
+}

--- a/components/tf_initialSeedCluster/aks/vnet.tf
+++ b/components/tf_initialSeedCluster/aks/vnet.tf
@@ -1,0 +1,47 @@
+# Virtual Network
+resource "azurerm_virtual_network" "aks" {
+  name                = "${var.cluster_name}-vnet"
+  location            = azurerm_resource_group.aks.location
+  resource_group_name = azurerm_resource_group.aks.name
+  address_space       = [var.vnet_cidr]
+  
+  tags = var.tags
+}
+
+# AKS Subnet
+resource "azurerm_subnet" "aks" {
+  name                 = "aks-subnet"
+  resource_group_name  = azurerm_resource_group.aks.name
+  virtual_network_name = azurerm_virtual_network.aks.name
+  address_prefixes     = [cidrsubnet(var.vnet_cidr, 4, 0)]
+}
+
+# Additional subnets for other services (similar to EKS public/private)
+resource "azurerm_subnet" "public" {
+  name                 = "public-subnet"
+  resource_group_name  = azurerm_resource_group.aks.name
+  virtual_network_name = azurerm_virtual_network.aks.name
+  address_prefixes     = [cidrsubnet(var.vnet_cidr, 4, 1)]
+}
+
+resource "azurerm_subnet" "private" {
+  name                 = "private-subnet"
+  resource_group_name  = azurerm_resource_group.aks.name
+  virtual_network_name = azurerm_virtual_network.aks.name
+  address_prefixes     = [cidrsubnet(var.vnet_cidr, 4, 2)]
+}
+
+# Network Security Group for AKS subnet
+resource "azurerm_network_security_group" "aks" {
+  name                = "${var.cluster_name}-nsg"
+  location            = azurerm_resource_group.aks.location
+  resource_group_name = azurerm_resource_group.aks.name
+  
+  tags = var.tags
+}
+
+# Associate NSG with AKS subnet
+resource "azurerm_subnet_network_security_group_association" "aks" {
+  subnet_id                 = azurerm_subnet.aks.id
+  network_security_group_id = azurerm_network_security_group.aks.id
+}


### PR DESCRIPTION
## Summary
- Add complete AKS (Azure Kubernetes Service) implementation as an alternative to EKS
- Mirror the existing EKS structure with Azure-specific resources
- Provide a working AKS cluster configuration without complex permissions setup

## Changes
- **main.tf**: AKS cluster with managed node pools, autoscaling, and system-assigned identity
- **vnet.tf**: Azure Virtual Network with subnets and network security groups
- **variables.tf**: Configurable parameters matching EKS structure (cluster name, region, sizes)
- **outputs.tf**: Essential outputs for cluster access and management
- **namespace.tf**: Flux namespace provisioning post-deployment

## Test Plan
- [x] Run `terraform init` in `components/tf_initialSeedCluster/aks/`
- [x] Authenticate with Azure CLI: `az login`
- [x] Run `terraform plan` to verify configuration
- [x] Run `terraform apply` to create the AKS cluster
- [x] Verify cluster access with `kubectl get nodes`
- [x] Confirm flux-system namespace exists

## Notes
- No complex IAM/permission setup required (uses Azure managed identity)
- Defaults to East US region with Standard_D2_v3 nodes
- Autoscaling configured from 1-3 nodes
- Azure CNI networking for better integration