### PR TITLE
Add cluster_name prefix to all IRSA roles

### DIFF
--- a/components/tf_initialSeedCluster/eks/alb-controller-iam.tf
+++ b/components/tf_initialSeedCluster/eks/alb-controller-iam.tf
@@ -4,7 +4,7 @@ data "http" "alb_controller_policy" {
 }
 
 resource "aws_iam_policy" "alb_controller_policy" {
-  name   = "AWSLoadBalancerControllerIAMPolicy"
+  name   = "${var.cluster_name}-AWSLoadBalancerControllerIAMPolicy"
   policy = data.http.alb_controller_policy.response_body
 }
 
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "alb_controller_assume_role" {
 
 resource "aws_iam_role" "alb_controller_role" {
   assume_role_policy = data.aws_iam_policy_document.alb_controller_assume_role.json
-  name               = "AmazonEKSLoadBalancerControllerRole"
+  name               = "${var.cluster_name}-AmazonEKSLoadBalancerControllerRole"
 }
 
 resource "aws_iam_role_policy_attachment" "alb_controller_policy_attachment" {

--- a/components/tf_initialSeedCluster/eks/capa-iam.tf
+++ b/components/tf_initialSeedCluster/eks/capa-iam.tf
@@ -1,6 +1,6 @@
 # IAM Role for Cluster API Provider AWS (CAPA)
 resource "aws_iam_role" "capa_controller" {
-  name = "capa-controller-role"
+  name = "${var.cluster_name}-capa-controller-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -26,7 +26,7 @@ resource "aws_iam_role" "capa_controller" {
 
 # Policy for CAPA controller to manage AWS resources
 resource "aws_iam_role_policy" "capa_controller" {
-  name = "capa-controller-policy"
+  name = "${var.cluster_name}-capa-controller-policy"
   role = aws_iam_role.capa_controller.id
 
   policy = jsonencode({

--- a/components/tf_initialSeedCluster/eks/crossplane-iam.tf
+++ b/components/tf_initialSeedCluster/eks/crossplane-iam.tf
@@ -1,6 +1,6 @@
 # IAM role for Crossplane AWS Provider
 resource "aws_iam_role" "crossplane_aws_provider" {
-  name = "CrossplaneAWSProviderRole"
+  name = "${var.cluster_name}-CrossplaneAWSProviderRole"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/components/tf_initialSeedCluster/eks/ebs-csi.tf
+++ b/components/tf_initialSeedCluster/eks/ebs-csi.tf
@@ -18,11 +18,11 @@ data "aws_iam_policy_document" "ebs_csi_assume_role" {
 
 resource "aws_iam_role" "ebs_csi_role" {
   assume_role_policy = data.aws_iam_policy_document.ebs_csi_assume_role.json
-  name               = "AmazonEKS_EBS_CSI_DriverRole"
+  name               = "${var.cluster_name}-AmazonEKS_EBS_CSI_DriverRole"
 }
 
 resource "aws_iam_policy" "ebs_csi_policy" {
-  name = "AmazonEKS_EBS_CSI_Driver_Policy"
+  name = "${var.cluster_name}-AmazonEKS_EBS_CSI_Driver_Policy"
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/components/tf_initialSeedCluster/eks/efs-csi.tf
+++ b/components/tf_initialSeedCluster/eks/efs-csi.tf
@@ -18,11 +18,11 @@ data "aws_iam_policy_document" "efs_csi_assume_role" {
 
 resource "aws_iam_role" "efs_csi_role" {
   assume_role_policy = data.aws_iam_policy_document.efs_csi_assume_role.json
-  name               = "AmazonEKS_EFS_CSI_DriverRole"
+  name               = "${var.cluster_name}-AmazonEKS_EFS_CSI_DriverRole"
 }
 
 resource "aws_iam_policy" "efs_csi_policy" {
-  name = "AmazonEKS_EFS_CSI_Driver_Policy"
+  name = "${var.cluster_name}-AmazonEKS_EFS_CSI_Driver_Policy"
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/components/tf_initialSeedCluster/eks/external-secrets-iam.tf
+++ b/components/tf_initialSeedCluster/eks/external-secrets-iam.tf
@@ -22,11 +22,11 @@ data "aws_iam_policy_document" "external_secrets_assume_role" {
 
 resource "aws_iam_role" "external_secrets_role" {
   assume_role_policy = data.aws_iam_policy_document.external_secrets_assume_role.json
-  name               = "ExternalSecretsOperatorRole"
+  name               = "${var.cluster_name}-ExternalSecretsOperatorRole"
 }
 
 resource "aws_iam_policy" "external_secrets_policy" {
-  name = "ExternalSecretsOperatorPolicy"
+  name = "${var.cluster_name}-ExternalSecretsOperatorPolicy"
 
   policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
## Summary
- Add cluster_name variable prefix to all IAM roles for service accounts (IRSA)
- Ensures unique role names when deploying multiple EKS clusters
- Updates both role names and associated policy names

## Changes Made
Updated the following IAM roles and policies to include `${var.cluster_name}-` prefix:

### Crossplane
- `CrossplaneAWSProviderRole` → `${var.cluster_name}-CrossplaneAWSProviderRole`

### External Secrets
- `ExternalSecretsOperatorRole` → `${var.cluster_name}-ExternalSecretsOperatorRole`
- `ExternalSecretsOperatorPolicy` → `${var.cluster_name}-ExternalSecretsOperatorPolicy`

### AWS Load Balancer Controller
- `AmazonEKSLoadBalancerControllerRole` → `${var.cluster_name}-AmazonEKSLoadBalancerControllerRole`
- `AWSLoadBalancerControllerIAMPolicy` → `${var.cluster_name}-AWSLoadBalancerControllerIAMPolicy`

### Cluster API Provider AWS (CAPA)
- `capa-controller-role` → `${var.cluster_name}-capa-controller-role`
- `capa-controller-policy` → `${var.cluster_name}-capa-controller-policy`

### EBS CSI Driver
- `AmazonEKS_EBS_CSI_DriverRole` → `${var.cluster_name}-AmazonEKS_EBS_CSI_DriverRole`
- `AmazonEKS_EBS_CSI_Driver_Policy` → `${var.cluster_name}-AmazonEKS_EBS_CSI_Driver_Policy`

### EFS CSI Driver
- `AmazonEKS_EFS_CSI_DriverRole` → `${var.cluster_name}-AmazonEKS_EFS_CSI_DriverRole`
- `AmazonEKS_EFS_CSI_Driver_Policy` → `${var.cluster_name}-AmazonEKS_EFS_CSI_Driver_Policy`

## Test Plan
- [ ] Run `terraform plan` to verify changes
- [ ] Deploy to test environment with non-default cluster name
- [ ] Verify all IRSA roles are created with correct names
- [ ] Test that service accounts can assume their respective roles
- [ ] Verify existing deployments with default cluster name continue to work