### PR TITLE
feat: Add Azure workload identity support to AKS bootstrap

### DIFF
--- a/components/tf_initialSeedCluster/aks/capz-identity.tf
+++ b/components/tf_initialSeedCluster/aks/capz-identity.tf
@@ -1,0 +1,38 @@
+# Managed Identity for Cluster API Provider Azure (CAPZ)
+resource "azurerm_user_assigned_identity" "capz" {
+  name                = "${var.cluster_name}-capz-identity"
+  resource_group_name = azurerm_resource_group.aks.name
+  location            = azurerm_resource_group.aks.location
+  tags                = var.tags
+}
+
+# Federated credential for CAPZ controller manager
+resource "azurerm_federated_identity_credential" "capz_controller" {
+  name                = "capz-controller-federated"
+  resource_group_name = azurerm_resource_group.aks.name
+  audience            = ["api://AzureADTokenExchange"]
+  parent_id           = azurerm_user_assigned_identity.capz.id
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  subject             = "system:serviceaccount:capz-system:capz-controller-manager"
+}
+
+# Role assignment for CAPZ to manage Azure resources
+resource "azurerm_role_assignment" "capz_contributor" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.capz.principal_id
+}
+
+# Additional role for CAPZ to manage network resources
+resource "azurerm_role_assignment" "capz_network_contributor" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.capz.principal_id
+}
+
+# Role assignment for CAPZ to manage role assignments (for managed identities)
+resource "azurerm_role_assignment" "capz_user_access_admin" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "User Access Administrator"
+  principal_id         = azurerm_user_assigned_identity.capz.principal_id
+}

--- a/components/tf_initialSeedCluster/aks/crossplane-identity.tf
+++ b/components/tf_initialSeedCluster/aks/crossplane-identity.tf
@@ -1,0 +1,35 @@
+# Data source for current Azure configuration
+data "azurerm_client_config" "current" {}
+
+# Managed Identity for Crossplane Provider Azure
+resource "azurerm_user_assigned_identity" "crossplane" {
+  name                = "${var.cluster_name}-crossplane-identity"
+  resource_group_name = azurerm_resource_group.aks.name
+  location            = azurerm_resource_group.aks.location
+  tags                = var.tags
+}
+
+# Federated credential for Crossplane service accounts
+# Using wildcard pattern to match dynamic service account names
+resource "azurerm_federated_identity_credential" "crossplane" {
+  name                = "crossplane-federated"
+  resource_group_name = azurerm_resource_group.aks.name
+  audience            = ["api://AzureADTokenExchange"]
+  parent_id           = azurerm_user_assigned_identity.crossplane.id
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  subject             = "system:serviceaccount:crossplane-system:provider-azure-*"
+}
+
+# Role assignment for Crossplane to manage resources in current subscription
+resource "azurerm_role_assignment" "crossplane_contributor" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.crossplane.principal_id
+}
+
+# Additional role for managing role assignments (needed for cross-subscription access)
+resource "azurerm_role_assignment" "crossplane_user_access_admin" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "User Access Administrator"
+  principal_id         = azurerm_user_assigned_identity.crossplane.principal_id
+}

--- a/components/tf_initialSeedCluster/aks/csi-identity.tf
+++ b/components/tf_initialSeedCluster/aks/csi-identity.tf
@@ -1,0 +1,49 @@
+# Managed Identity for Azure Disk CSI Driver
+resource "azurerm_user_assigned_identity" "azure_disk_csi" {
+  name                = "${var.cluster_name}-azure-disk-csi-identity"
+  resource_group_name = azurerm_resource_group.aks.name
+  location            = azurerm_resource_group.aks.location
+  tags                = var.tags
+}
+
+# Federated credential for Azure Disk CSI Driver
+resource "azurerm_federated_identity_credential" "azure_disk_csi" {
+  name                = "azure-disk-csi-federated"
+  resource_group_name = azurerm_resource_group.aks.name
+  audience            = ["api://AzureADTokenExchange"]
+  parent_id           = azurerm_user_assigned_identity.azure_disk_csi.id
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  subject             = "system:serviceaccount:kube-system:csi-azuredisk-node-sa"
+}
+
+# Role assignment for Azure Disk CSI to manage disks
+resource "azurerm_role_assignment" "azure_disk_csi_contributor" {
+  scope                = azurerm_resource_group.aks.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.azure_disk_csi.principal_id
+}
+
+# Managed Identity for Azure File CSI Driver
+resource "azurerm_user_assigned_identity" "azure_file_csi" {
+  name                = "${var.cluster_name}-azure-file-csi-identity"
+  resource_group_name = azurerm_resource_group.aks.name
+  location            = azurerm_resource_group.aks.location
+  tags                = var.tags
+}
+
+# Federated credential for Azure File CSI Driver
+resource "azurerm_federated_identity_credential" "azure_file_csi" {
+  name                = "azure-file-csi-federated"
+  resource_group_name = azurerm_resource_group.aks.name
+  audience            = ["api://AzureADTokenExchange"]
+  parent_id           = azurerm_user_assigned_identity.azure_file_csi.id
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  subject             = "system:serviceaccount:kube-system:csi-azurefile-node-sa"
+}
+
+# Role assignment for Azure File CSI to manage storage accounts
+resource "azurerm_role_assignment" "azure_file_csi_contributor" {
+  scope                = azurerm_resource_group.aks.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.azure_file_csi.principal_id
+}

--- a/components/tf_initialSeedCluster/aks/external-secrets-identity.tf
+++ b/components/tf_initialSeedCluster/aks/external-secrets-identity.tf
@@ -1,0 +1,49 @@
+# Create a Key Vault for storing secrets
+resource "azurerm_key_vault" "main" {
+  name                = "${substr(replace(var.cluster_name, "-", ""), 0, 20)}kv"
+  resource_group_name = azurerm_resource_group.aks.name
+  location            = azurerm_resource_group.aks.location
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  # Enable RBAC authorization
+  enable_rbac_authorization = true
+
+  # Soft delete and purge protection
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = false # Set to true in production
+
+  tags = var.tags
+}
+
+# Managed Identity for External Secrets Operator
+resource "azurerm_user_assigned_identity" "external_secrets" {
+  name                = "${var.cluster_name}-external-secrets-identity"
+  resource_group_name = azurerm_resource_group.aks.name
+  location            = azurerm_resource_group.aks.location
+  tags                = var.tags
+}
+
+# Federated credential for External Secrets service account
+resource "azurerm_federated_identity_credential" "external_secrets" {
+  name                = "external-secrets-federated"
+  resource_group_name = azurerm_resource_group.aks.name
+  audience            = ["api://AzureADTokenExchange"]
+  parent_id           = azurerm_user_assigned_identity.external_secrets.id
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  subject             = "system:serviceaccount:external-secrets:external-secrets"
+}
+
+# Role assignment for External Secrets to read from Key Vault
+resource "azurerm_role_assignment" "external_secrets_key_vault_reader" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.external_secrets.principal_id
+}
+
+# Also grant the current user/service principal access to manage secrets
+resource "azurerm_role_assignment" "current_user_key_vault_admin" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Administrator"
+  principal_id         = data.azurerm_client_config.current.object_id
+}

--- a/components/tf_initialSeedCluster/aks/k8s-outputs.tf
+++ b/components/tf_initialSeedCluster/aks/k8s-outputs.tf
@@ -1,0 +1,42 @@
+# Create a ConfigMap with Terraform outputs for use by Flux
+resource "kubernetes_config_map" "terraform_outputs" {
+  metadata {
+    name      = "terraform-outputs"
+    namespace = "flux-system"
+  }
+
+  data = {
+    # Azure tenant and subscription information
+    AZURE_TENANT_ID       = data.azurerm_client_config.current.tenant_id
+    AZURE_SUBSCRIPTION_ID = data.azurerm_client_config.current.subscription_id
+    
+    # Cluster information
+    CLUSTER_NAME          = var.cluster_name
+    RESOURCE_GROUP        = azurerm_resource_group.aks.name
+    LOCATION              = azurerm_resource_group.aks.location
+    
+    # Network information
+    VNET_ID               = azurerm_virtual_network.aks.id
+    VNET_NAME             = azurerm_virtual_network.aks.name
+    SUBNET_ID             = azurerm_subnet.aks.id
+    
+    # OIDC information for workload identity
+    OIDC_ISSUER_URL       = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+    
+    # Managed Identity Client IDs (for workload identity)
+    CROSSPLANE_CLIENT_ID      = azurerm_user_assigned_identity.crossplane.client_id
+    AZURE_DISK_CSI_CLIENT_ID  = azurerm_user_assigned_identity.azure_disk_csi.client_id
+    AZURE_FILE_CSI_CLIENT_ID  = azurerm_user_assigned_identity.azure_file_csi.client_id
+    EXTERNAL_SECRETS_CLIENT_ID = azurerm_user_assigned_identity.external_secrets.client_id
+    CAPZ_CLIENT_ID            = azurerm_user_assigned_identity.capz.client_id
+    
+    # Key Vault information
+    KEY_VAULT_NAME        = azurerm_key_vault.main.name
+    KEY_VAULT_URI         = azurerm_key_vault.main.vault_uri
+  }
+
+  depends_on = [
+    azurerm_kubernetes_cluster.aks,
+    kubernetes_namespace.flux_system
+  ]
+}

--- a/components/tf_initialSeedCluster/aks/main.tf
+++ b/components/tf_initialSeedCluster/aks/main.tf
@@ -45,6 +45,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
   dns_prefix          = var.cluster_name
   kubernetes_version  = var.kubernetes_version
 
+  # Enable workload identity and OIDC for pod authentication
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
   default_node_pool {
     name       = "default"
     node_count = var.node_count

--- a/components/tf_initialSeedCluster/aks/outputs.tf
+++ b/components/tf_initialSeedCluster/aks/outputs.tf
@@ -49,3 +49,44 @@ output "node_resource_group" {
   description = "Name of the auto-generated resource group for AKS nodes"
   value       = azurerm_kubernetes_cluster.aks.node_resource_group
 }
+
+# Workload Identity outputs
+output "oidc_issuer_url" {
+  description = "OIDC issuer URL for workload identity"
+  value       = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+}
+
+output "crossplane_identity_client_id" {
+  description = "Client ID of the Crossplane managed identity"
+  value       = azurerm_user_assigned_identity.crossplane.client_id
+}
+
+output "azure_disk_csi_identity_client_id" {
+  description = "Client ID of the Azure Disk CSI managed identity"
+  value       = azurerm_user_assigned_identity.azure_disk_csi.client_id
+}
+
+output "azure_file_csi_identity_client_id" {
+  description = "Client ID of the Azure File CSI managed identity"
+  value       = azurerm_user_assigned_identity.azure_file_csi.client_id
+}
+
+output "external_secrets_identity_client_id" {
+  description = "Client ID of the External Secrets managed identity"
+  value       = azurerm_user_assigned_identity.external_secrets.client_id
+}
+
+output "capz_identity_client_id" {
+  description = "Client ID of the CAPZ managed identity"
+  value       = azurerm_user_assigned_identity.capz.client_id
+}
+
+output "key_vault_name" {
+  description = "Name of the Key Vault"
+  value       = azurerm_key_vault.main.name
+}
+
+output "key_vault_uri" {
+  description = "URI of the Key Vault"
+  value       = azurerm_key_vault.main.vault_uri
+}


### PR DESCRIPTION
## Summary
- Extends the AKS Terraform bootstrap module to support Azure workload identity
- Enables secure pod-level authentication without static credentials
- Provides parity with AWS IRSA implementation

## Changes
### AKS Cluster Configuration
- Enabled `oidc_issuer_enabled` and `workload_identity_enabled` on the AKS cluster
- These settings are required for workload identity authentication

### Managed Identities Created
1. **Crossplane** (`crossplane-identity.tf`)
   - Uses wildcard federated credential pattern for dynamic service accounts
   - Contributor and User Access Administrator roles at subscription level

2. **Azure CSI Drivers** (`csi-identity.tf`)
   - Azure Disk CSI driver identity
   - Azure File CSI driver identity
   - Both with appropriate storage permissions

3. **External Secrets** (`external-secrets-identity.tf`)
   - Includes Key Vault creation for secret storage
   - Key Vault Secrets User role for the operator

4. **CAPZ** (`capz-identity.tf`)
   - Cluster API Provider Azure identity
   - Contributor, Network Contributor, and User Access Administrator roles

### Kubernetes Integration
- Added `k8s-outputs.tf` to create ConfigMap with all identity client IDs
- ConfigMap enables Flux variable substitution for Helm values
- Updated `outputs.tf` with new workload identity outputs

## Test Plan
- [ ] Deploy AKS cluster with `terraform apply`
- [ ] Verify workload identity is enabled: `az aks show -n <cluster> -g <rg> --query "oidcIssuerProfile"`
- [ ] Check managed identities are created
- [ ] Verify ConfigMap is created in flux-system namespace
- [ ] Test Crossplane provider can authenticate using workload identity