### PR TITLE
feat: Add Crossplane Azure provider with workload identity

### DIFF
--- a/components/helmrelease/crossplane/azure-workload-identity.yaml
+++ b/components/helmrelease/crossplane/azure-workload-identity.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: provider-azure
+  namespace: crossplane-system
+  labels:
+    azure.workload.identity/use: "true"
+  annotations:
+    azure.workload.identity/client-id: "${CROSSPLANE_CLIENT_ID}"
+    azure.workload.identity/tenant-id: "${AZURE_TENANT_ID}"

--- a/components/helmrelease/crossplane/kustomization.yaml
+++ b/components/helmrelease/crossplane/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - providers/
   - compositions/
   - aws-iam.yaml
+  - azure-workload-identity.yaml
   - configurations/
 
 namespace: crossplane-system

--- a/components/helmrelease/crossplane/providers/kustomization.yaml
+++ b/components/helmrelease/crossplane/providers/kustomization.yaml
@@ -4,5 +4,8 @@ kind: Kustomization
 resources:
   - provider-aws.yaml
   - provider-aws-config.yaml
+  - provider-azure.yaml
+  - provider-azure-controller-config.yaml
+  - provider-azure-config.yaml
   - provider-helm.yaml
   - provider-kubernetes.yaml

--- a/components/helmrelease/crossplane/providers/provider-azure-config.yaml
+++ b/components/helmrelease/crossplane/providers/provider-azure-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: azure.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: InjectedIdentity
+  subscriptionID: "${AZURE_SUBSCRIPTION_ID}"
+  tenantID: "${AZURE_TENANT_ID}"
+  clientID: "${CROSSPLANE_CLIENT_ID}"

--- a/components/helmrelease/crossplane/providers/provider-azure-controller-config.yaml
+++ b/components/helmrelease/crossplane/providers/provider-azure-controller-config.yaml
@@ -1,0 +1,30 @@
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: provider-azure-controller-config
+  labels:
+    app: crossplane-provider-azure
+spec:
+  podSecurityContext:
+    runAsUser: 2000
+    runAsGroup: 2000
+    fsGroup: 2000
+  args:
+    - --debug
+  env:
+    - name: AZURE_SDK_GO_LOGGING
+      value: "all"
+  serviceAccountName: provider-azure
+  metadata:
+    labels:
+      azure.workload.identity/use: "true"
+    annotations:
+      azure.workload.identity/client-id: "${CROSSPLANE_CLIENT_ID}"
+      azure.workload.identity/tenant-id: "${AZURE_TENANT_ID}"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi

--- a/components/helmrelease/crossplane/providers/provider-azure.yaml
+++ b/components/helmrelease/crossplane/providers/provider-azure.yaml
@@ -1,0 +1,11 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-azure
+spec:
+  package: xpkg.upbound.io/upbound/provider-azure:v0.42.0
+  controllerConfigRef:
+    name: provider-azure-controller-config
+  revisionHistoryLimit: 3
+  revisionActivationPolicy: Automatic
+  packagePullPolicy: IfNotPresent

--- a/components/kustomizations/azure-subscription-namespace/kustomization.yaml
+++ b/components/kustomizations/azure-subscription-namespace/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - provider-config.yaml
+
+namespace: azure-${SUBSCRIPTION_ALIAS}

--- a/components/kustomizations/azure-subscription-namespace/provider-config.yaml
+++ b/components/kustomizations/azure-subscription-namespace/provider-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: azure.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: ${SUBSCRIPTION_ALIAS}
+spec:
+  credentials:
+    source: InjectedIdentity
+  subscriptionID: "${SUBSCRIPTION_ID}"
+  tenantID: "${AZURE_TENANT_ID}"
+  clientID: "${CROSSPLANE_CLIENT_ID}"


### PR DESCRIPTION
## Summary
- Adds Crossplane Azure provider v0.42.0 with workload identity authentication
- Enables provisioning of Azure resources through Crossplane
- Provides multi-subscription support pattern

## Changes
### Provider Installation
1. **Provider Resource** (`provider-azure.yaml`)
   - Uses Upbound's Azure provider v0.42.0
   - References controller config for pod customization

2. **ControllerConfig** (`provider-azure-controller-config.yaml`)
   - Configures workload identity labels and annotations
   - Sets resource limits and debug logging
   - Uses variable substitution for client ID and tenant ID

3. **ProviderConfig** (`provider-azure-config.yaml`)
   - Default config using InjectedIdentity (workload identity)
   - References Azure subscription and tenant from ConfigMap

### Authentication Setup
- **ServiceAccount** (`azure-workload-identity.yaml`)
  - Configured with workload identity annotations
  - Matches the federated credential created in Terraform

### Multi-Subscription Support
- **Template** (`azure-subscription-namespace/`)
  - ProviderConfig template for different subscriptions
  - Uses variable substitution for subscription-specific values

## Test Plan
- [ ] Deploy to management cluster with `flux reconcile`
- [ ] Verify provider pod starts with workload identity
- [ ] Check provider is healthy: `kubectl get providers.pkg.crossplane.io`
- [ ] Test creating a simple Azure resource (e.g., ResourceGroup)
- [ ] Verify authentication works without static credentials

## Dependencies
- Requires PR #8 (Azure workload identity Terraform) to be deployed first
- Terraform outputs ConfigMap must exist in flux-system namespace